### PR TITLE
Use setlocale with None to retrieve existing locale

### DIFF
--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -90,7 +90,7 @@ def getUserLocale(localeCode: str = '') -> tuple[LocaleDict, str | None]:
     :return: Tuple of local conventions dictionary and a user-directed setup message
     """
     import locale
-    currentLocale = locale.getlocale()
+    currentLocale = locale.setlocale(locale.LC_ALL)
     try:
         return _getUserLocaleUnsafe(localeCode)
     finally:

--- a/tests/unit_tests/arelle/test_locale.py
+++ b/tests/unit_tests/arelle/test_locale.py
@@ -67,7 +67,7 @@ def test_format_decimal(params: dict[str, Any], result: str) -> None:
 
 @pytest.mark.parametrize('locale_code', ['', 'C', 'invalid'])
 def test_get_user_locale_reset(locale_code) -> None:
-    before_locale = locale.getlocale()[0]
+    before_locale = locale.setlocale(locale.LC_ALL)
     getUserLocale(locale_code)
-    after_locale = locale.getlocale()[0]
+    after_locale = locale.setlocale(locale.LC_ALL)
     assert after_locale == before_locale


### PR DESCRIPTION
language code and encoding returned by getlocale aren't always unique (see C.UTF-8)

#### Reason for change


#### Description of change


#### Steps to Test

**review**:
@Arelle/arelle
